### PR TITLE
fix(copy): update merchant CTA labels for new static signup page (ENG-269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ padding: 6px 12px;
 - **Fiat First** — always show JMD amounts before Bitcoin/sats.
 - **No "remittance"** — replaced sitewide with "send money home" / "transfer" / "family payment".
 - **No Western Union brand mentions** anywhere on the site.
-- **Merchant POS signup** always → `https://signup.getflash.io`
+- **Merchant signup** always → `https://signup.getflash.io` (static one-pager; in-app upgrade is the primary path)
 - **Fee accuracy:** Flash transfer fee = 0%; on-ramp = 1–3% (third-party); cash-out to Jamaican bank = 2% (Flash fee).
 
 ### Navigation

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
                 </li>
               </ul>
               <a href="https://signup.getflash.io" target="_blank" rel="noopener noreferrer" class="btn-soft" style="margin-top:8px;">
-                Set up your business
+                Become a Flash Merchant
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
                   <line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>
                 </svg>
@@ -561,7 +561,7 @@
               <p>Join merchants across the Caribbean accepting Bitcoin payments. Setup is free, takes under 30 minutes, and requires no hardware.</p>
             </div>
             <div style="display:flex;gap:12px;flex-shrink:0;flex-wrap:wrap;">
-              <a href="https://signup.getflash.io" target="_blank" rel="noopener noreferrer" class="btn-primary">Get Flash POS</a>
+              <a href="https://signup.getflash.io" target="_blank" rel="noopener noreferrer" class="btn-primary">Become a Merchant</a>
               <a href="/map" class="btn-secondary">See merchant map</a>
             </div>
           </div>


### PR DESCRIPTION
## ENG-269 — Update references to signup.getflash.io

The old Supabase web form is replaced by the new static one-pager. Users upgrade in-app (Settings → Account → Upgrade Account).

**Changes:**
- `index.html:440` — Renamed CTA from "Set up your business" → "Become a Flash Merchant"
- `index.html:564` — Renamed CTA from "Get Flash POS" → "Become a Merchant"
- `README.md:180` — Updated description to reflect static page + in-app upgrade path
- `map/index.html` — No change needed ("Become a merchant" label already correct)

URLs are unchanged (`https://signup.getflash.io` — still valid, now serves static page).