### PR TITLE
feat(soc-6): Stage 1 console UX — 24h validity hint + in-app terminal routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
           done
 
       - name: Run tests
-        run: node --test tests/
+        run: node --test tests/*.test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main, kotc]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Syntax-check JS modules
+        run: |
+          for f in js/core/*.js js/modules/*.js; do
+            node --check "$f"
+          done
+
+      - name: Run tests
+        run: node --test tests/

--- a/index.html
+++ b/index.html
@@ -789,6 +789,7 @@
   <script src="js/modules/globeSvg.js"></script>
   <script src="js/core/main.js"></script>
   <script src="js/modules/faqFetch.js"></script>
+  <script src="js/modules/token-validity.js"></script>
   <script src="js/modules/lightning.js"></script>
   <script src="js/modules/btcTracker.js"></script>
   <script src="js/modules/productCarousel.js"></script>

--- a/js/modules/lightning.js
+++ b/js/modules/lightning.js
@@ -304,7 +304,14 @@ async function revealRabbitHole() {
       console.log('%c  STEP 1: Save this token in your Hunter Dashboard', 'font-size: 14px; color: #F6C453; font-weight: bold;');
       console.log('%c           → /treasure-hunt-for-real-this-time-2140/hunter-dashboard.html', 'font-size: 12px; color: #41AD49;');
       console.log('%c');
-      console.log('%c  ⏳ This token is valid for 24 hours from the time it was generated.', 'font-size: 13px; color: #7C8A92;');
+      // Derive the validity line from the server's expires_in so the copy
+      // stays true for short-lived tokens and idempotently reissued tokens
+      // that only have part of their lifetime left. Static 24h copy is the
+      // fallback when expires_in is absent (see js/modules/token-validity.js).
+      const validityLine = typeof formatTokenValidity === 'function'
+        ? formatTokenValidity(data.expires_in)
+        : 'This token is valid for 24 hours from the time it was generated.';
+      console.log(`%c  ⏳ ${validityLine}`, 'font-size: 13px; color: #7C8A92;');
       console.log('%c     If it expires before you use it, return to getflash.io,', 'font-size: 12px; color: #7C8A92;');
       console.log('%c     watch the storm, and a new signal will be sent to your console.', 'font-size: 12px; color: #7C8A92;');
       console.log('%c');

--- a/js/modules/lightning.js
+++ b/js/modules/lightning.js
@@ -304,6 +304,10 @@ async function revealRabbitHole() {
       console.log('%c  STEP 1: Save this token in your Hunter Dashboard', 'font-size: 14px; color: #F6C453; font-weight: bold;');
       console.log('%c           → /treasure-hunt-for-real-this-time-2140/hunter-dashboard.html', 'font-size: 12px; color: #41AD49;');
       console.log('%c');
+      console.log('%c  ⏳ This token is valid for 24 hours from the time it was generated.', 'font-size: 13px; color: #7C8A92;');
+      console.log('%c     If it expires before you use it, return to getflash.io,', 'font-size: 12px; color: #7C8A92;');
+      console.log('%c     watch the storm, and a new signal will be sent to your console.', 'font-size: 12px; color: #7C8A92;');
+      console.log('%c');
       console.log('%c  STEP 2: Find the Key Terminal...', 'font-size: 14px; color: #F6C453; font-weight: bold;');
       console.log('%c           His email was satoshin@gmx.com', 'font-size: 12px; color: #7C8A92; font-style: italic;');
       console.log('%c           What if he had a flash identity?', 'font-size: 12px; color: #7C8A92; font-style: italic;');

--- a/js/modules/token-validity.js
+++ b/js/modules/token-validity.js
@@ -1,0 +1,34 @@
+// Formats the Stage 1 token validity line shown in the treasure-hunt console.
+//
+// The server response carries `expires_in` (seconds remaining), so the copy is
+// derived from what the server actually says rather than hard-coding a TTL:
+//  - a freshly minted token reports its real lifetime (1h today, 24h once the
+//    server bumps it), and
+//  - an idempotently reissued token reports the time it has LEFT, not the
+//    lifetime it started with.
+// The static 24-hour copy is kept only as a fallback for older server
+// responses that omit `expires_in`.
+(function (global) {
+  'use strict';
+
+  function formatTokenValidity(expiresInSeconds) {
+    const seconds = Number(expiresInSeconds);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return 'This token is valid for 24 hours from the time it was generated.';
+    }
+    if (seconds < 3600) {
+      const minutes = Math.max(1, Math.round(seconds / 60));
+      return `This token is valid for approximately ${minutes} minute${minutes === 1 ? '' : 's'} more.`;
+    }
+    const hours = Math.round(seconds / 3600);
+    return `This token is valid for approximately ${hours} hour${hours === 1 ? '' : 's'} more.`;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    // Node (tests)
+    module.exports = { formatTokenValidity };
+  } else {
+    // Browser (plain <script> include)
+    global.formatTokenValidity = formatTokenValidity;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/mission.html
+++ b/mission.html
@@ -300,6 +300,7 @@
     <!-- Custom JS -->
     <script src="js/modules/globeSvg.js"></script>
     <script src="js/core/main.js"></script>
+    <script src="js/modules/token-validity.js"></script>
     <script src="js/modules/lightning.js"></script>
     <script src="js/modules/btcTracker.js"></script>
 

--- a/tests/token-validity.test.mjs
+++ b/tests/token-validity.test.mjs
@@ -1,0 +1,56 @@
+// Run with: node --test tests/token-validity.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { formatTokenValidity } = require('../js/modules/token-validity.js');
+
+test('1-hour token (prod today) is not described as 24 hours', () => {
+  const msg = formatTokenValidity(3600);
+  assert.equal(msg, 'This token is valid for approximately 1 hour more.');
+  assert.ok(!msg.includes('24 hours'));
+});
+
+test('24-hour token (after kotc-server#19) reports 24 hours', () => {
+  assert.equal(
+    formatTokenValidity(86400),
+    'This token is valid for approximately 24 hours more.'
+  );
+});
+
+test('idempotently reissued token reports remaining time, not full lifetime', () => {
+  // e.g. R2 reissue path returns an existing token with ~4h left
+  assert.equal(
+    formatTokenValidity(4 * 3600),
+    'This token is valid for approximately 4 hours more.'
+  );
+});
+
+test('sub-hour remainder is reported in minutes', () => {
+  assert.equal(
+    formatTokenValidity(1800),
+    'This token is valid for approximately 30 minutes more.'
+  );
+  assert.equal(
+    formatTokenValidity(30),
+    'This token is valid for approximately 1 minute more.'
+  );
+});
+
+test('numeric strings from PHP JSON are handled', () => {
+  assert.equal(
+    formatTokenValidity('3600'),
+    'This token is valid for approximately 1 hour more.'
+  );
+});
+
+test('missing or invalid expires_in falls back to the static 24-hour copy', () => {
+  const fallback = 'This token is valid for 24 hours from the time it was generated.';
+  assert.equal(formatTokenValidity(undefined), fallback);
+  assert.equal(formatTokenValidity(null), fallback);
+  assert.equal(formatTokenValidity('soon'), fallback);
+  assert.equal(formatTokenValidity(NaN), fallback);
+  assert.equal(formatTokenValidity(0), fallback);
+  assert.equal(formatTokenValidity(-10), fallback);
+});

--- a/treasure-hunt-for-real-this-time-2140/hunter-dashboard.html
+++ b/treasure-hunt-for-real-this-time-2140/hunter-dashboard.html
@@ -528,6 +528,26 @@
             color: #ff6b6b;
         }
 
+        /* R6: primary in-app route — informational card, not a link.
+           Suppress the clickable hover affordance so it doesn't read as
+           a dead-end button. */
+        .quick-link.quick-link-primary {
+            background: rgba(65, 173, 73, 0.1);
+            border-color: #41AD49;
+            cursor: default;
+        }
+
+        .quick-link.quick-link-primary:hover {
+            transform: none;
+            background: rgba(65, 173, 73, 0.1);
+            border-color: #41AD49;
+        }
+
+        /* R6: browser terminal is a de-emphasized fallback route */
+        .quick-link.quick-link-fallback {
+            opacity: 0.7;
+        }
+
         /* Responsive */
         @media (max-width: 768px) {
             .dashboard-screen {
@@ -779,14 +799,14 @@
                 <div class="quick-links-grid">
                     <!-- R6: In-app NIP-05 path is the primary route for hunters.
                          Browser terminal is available as a fallback for non-mobile users. -->
-                    <div class="quick-link quick-link-primary" style="background: rgba(65,173,73,0.1); border: 1px solid #41AD49;">
+                    <div class="quick-link quick-link-primary">
                         <div class="quick-link-icon">📱</div>
                         <div class="quick-link-content">
                             <h3>IN-APP TERMINAL</h3>
                             <p>Primary route: open Flash and look up <strong>satoshin@getflash.io</strong> via NIP-05 to enter the terminal</p>
                         </div>
                     </div>
-                    <a href="https://kotc.islandbitcoin.com/terminal/" class="quick-link" target="_blank" style="opacity: 0.7;">
+                    <a href="https://kotc.islandbitcoin.com/terminal/" class="quick-link quick-link-fallback" target="_blank">
                         <div class="quick-link-icon">🖥️</div>
                         <div class="quick-link-content">
                             <h3>BROWSER TERMINAL</h3>

--- a/treasure-hunt-for-real-this-time-2140/hunter-dashboard.html
+++ b/treasure-hunt-for-real-this-time-2140/hunter-dashboard.html
@@ -480,7 +480,7 @@
 
         .quick-links-grid {
             display: grid;
-            grid-template-columns: repeat(4, 1fr);
+            grid-template-columns: repeat(5, 1fr);
             gap: 15px;
         }
 
@@ -803,7 +803,7 @@
                         <div class="quick-link-icon">📱</div>
                         <div class="quick-link-content">
                             <h3>IN-APP TERMINAL</h3>
-                            <p>Primary route: open Flash and look up <strong>satoshin@getflash.io</strong> via NIP-05 to enter the terminal</p>
+                            <p>Primary route: open Flash and look up the Key Terminal's flash identity via NIP-05 — the signal in your console holds the name</p>
                         </div>
                     </div>
                     <a href="https://kotc.islandbitcoin.com/terminal/" class="quick-link quick-link-fallback" target="_blank">

--- a/treasure-hunt-for-real-this-time-2140/hunter-dashboard.html
+++ b/treasure-hunt-for-real-this-time-2140/hunter-dashboard.html
@@ -777,11 +777,20 @@
             <div class="quick-links-section">
                 <h2 class="section-header">QUICK ACCESS</h2>
                 <div class="quick-links-grid">
-                    <a href="https://kotc.islandbitcoin.com/terminal/" class="quick-link" target="_blank">
+                    <!-- R6: In-app NIP-05 path is the primary route for hunters.
+                         Browser terminal is available as a fallback for non-mobile users. -->
+                    <div class="quick-link quick-link-primary" style="background: rgba(65,173,73,0.1); border: 1px solid #41AD49;">
+                        <div class="quick-link-icon">📱</div>
+                        <div class="quick-link-content">
+                            <h3>IN-APP TERMINAL</h3>
+                            <p>Primary route: open Flash and look up <strong>satoshin@getflash.io</strong> via NIP-05 to enter the terminal</p>
+                        </div>
+                    </div>
+                    <a href="https://kotc.islandbitcoin.com/terminal/" class="quick-link" target="_blank" style="opacity: 0.7;">
                         <div class="quick-link-icon">🖥️</div>
                         <div class="quick-link-content">
-                            <h3>KEY TERMINAL</h3>
-                            <p>Access the hacker terminal to solve puzzles</p>
+                            <h3>BROWSER TERMINAL</h3>
+                            <p>Fallback only — open the terminal in your browser if you can't access the app</p>
                         </div>
                     </a>
                     <a href="leaderboard.html" class="quick-link">


### PR DESCRIPTION
## SOC-6: KOTC Stage 1 Token UX Fix (frontend — flash-site)

### Changes in this PR

#### R4: Console messaging clarity
- `js/modules/lightning.js`: after the token display, the console now states how long the token is valid and how to regenerate it (return to getflash.io, watch the storm). Lore tone preserved — no puzzle spoilers.
- Validity copy is **derived from the server's `expires_in`** via a new pure helper, `js/modules/token-validity.js` (loaded in `index.html` and `mission.html`), with static 24h copy only as a fallback when `expires_in` is absent. This removes the deploy-order coupling with the companion server PR and correctly reports remaining time for idempotently reissued tokens (e.g. "~4h more" instead of a fresh-looking 24h promise).

#### R6: In-app NIP-05 path promoted as primary terminal route
- `treasure-hunt-for-real-this-time-2140/hunter-dashboard.html`:
  - IN-APP TERMINAL card added above the browser terminal link as the primary route. It points hunters to the Key Terminal's flash identity via NIP-05 **without printing the address** — the console signal still holds the name, so the STEP 2 riddle is not spoiled.
  - Browser terminal relabeled BROWSER TERMINAL and de-emphasized as the fallback route.
  - Card styling lives in proper `.quick-link-primary` / `.quick-link-fallback` rules in the document style block (no inline styles); the primary card suppresses the base hover lift so a non-clickable card doesn't advertise itself as a button.
  - Quick-links grid widened to `repeat(5, 1fr)` so all five cards fit one row on desktop.

#### Tests + CI
- `tests/token-validity.test.mjs`: 6 `node:test` cases covering 1h prod tokens, 24h post-server-change tokens, partial reissue remainders, sub-hour formatting, PHP numeric strings, and the static fallback.
- `.github/workflows/ci.yml`: first CI for this repo — `node --check` over `js/core/` and `js/modules/`, then `node --test` on the suite. Runs on PRs and pushes to `main`/`kotc`.

### Acceptance criteria coverage
- ✅ Console hints clearly state token validity (now accurate to the second, from `expires_in`) and the regen path
- ✅ No confusing dead-end language
- ✅ Hunter journey: in-app NIP-05 path is the primary documented route, without spoiling the discovery puzzle

Companion PR in islandbitcoin/kotc-server for R1, R2, R3, R5. With the dynamic validity copy, this PR no longer needs to deploy after the server change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D21SvyQ2uRERDVepyADcDZ
