### PR TITLE
Nav Docs link + Google Maps key replacement

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -82,6 +82,9 @@
         <!-- Blog -->
         <li><a href="/blog/" class="nav-link">Blog</a></li>
 
+        <!-- Help / user guides -->
+        <li><a href="https://userdocs.flashapp.me" class="nav-link">Help</a></li>
+
         <!-- Mobile CTA -->
         <li class="mobile-only nav-mobile-cta">
           <a href="/app/" class="nav-cta">Get Flash ↗</a>

--- a/components/header.html
+++ b/components/header.html
@@ -82,8 +82,8 @@
         <!-- Blog -->
         <li><a href="/blog/" class="nav-link">Blog</a></li>
 
-        <!-- Help / user guides -->
-        <li><a href="https://userdocs.flashapp.me" class="nav-link">Help</a></li>
+        <!-- Docs / user guides -->
+        <li><a href="https://userdocs.flashapp.me" class="nav-link">Docs</a></li>
 
         <!-- Mobile CTA -->
         <li class="mobile-only nav-mobile-cta">

--- a/map/index.html
+++ b/map/index.html
@@ -671,7 +671,7 @@
     function initMap() { window.initMapCallback && window.initMapCallback(); }
   </script>
   <script async defer
-    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBrZtvg_PSLuDUcMQ9BapDyTlc821oLM2w&libraries=places,marker&callback=initMap&loading=async">
+    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDUOea1hwA9QI2HLjbfvcJHE3r1LxLJag8&libraries=places,marker&callback=initMap&loading=async">
   </script>
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-FH0PPEWMBP"></script>

--- a/merchant/index.html
+++ b/merchant/index.html
@@ -19,7 +19,7 @@
   <script src="https://unpkg.com/nostr-tools@2.23.3/lib/nostr.bundle.js"></script>
   <!-- Google Maps (Places only) -->
   <script>function initMap(){}</script>
-  <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBrZtvg_PSLuDUcMQ9BapDyTlc821oLM2w&libraries=places&callback=initMap&loading=async"></script>
+  <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDUOea1hwA9QI2HLjbfvcJHE3r1LxLJag8&libraries=places&callback=initMap&loading=async"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
## What's in here

Three commits already live on prod (droplet) — this PR reconciles them into `main`:

- **Docs nav link** — adds a "Docs" item to the main menu (desktop + mobile drawer) linking to https://userdocs.flashapp.me, part of the ColdCard-advisory docs push (July 31).
- **Google Maps key replacement** — replaces the deleted exposed "Sales Key" with the new referrer-restricted key (live since July 25). The key is referrer-locked to getflash.io, so committing it is safe — it ships in page source regardless.

## Deploy note

Merging to `main` does **not** deploy prod (droplet is rsync-only; these files are already live there). Vercel staging will pick it up per its branch config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AP1XZs5anZjsHYgGRGVyDT