### PR TITLE
ci: add gitleaks secret scanning + CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, kotc]
+  pull_request:
+  schedule:
+    - cron: '30 9 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (javascript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,19 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [main, kotc]
+  pull_request:
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Scans the checked-out tree (--no-git): the gate is "no secrets in the
+      # code as it stands", so a historical leak can't permanently fail CI.
+      - name: Run gitleaks
+        run: |
+          docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:v8.30.1 \
+            detect --source=/repo --no-git --redact --no-banner

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+# Gitleaks config — extends the default ruleset with allowlists for
+# client-side identifiers that are public by design.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Chatwoot website widget token — public by design, embedded on every page for visitors"
+regexes = ['''8J2iDCw5f6dgxGa1UFvP1aww''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,3 +7,14 @@ useDefault = true
 [[allowlists]]
 description = "Chatwoot website widget token — public by design, embedded on every page for visitors"
 regexes = ['''8J2iDCw5f6dgxGa1UFvP1aww''']
+
+[[allowlists]]
+# NWC connection for the donations lightning-messageboard. Deliberately embedded:
+# scoped receive-only in Alby Hub (create/lookup invoices + read history, no
+# pay_invoice) — verified 2026-08-12, Alby app ID 5 "Keys of the Caribbean".
+# Only NWC URIs on this one page are allowlisted; other secrets there still fail.
+description = "Receive-only NWC connection embedded for the donations message board"
+condition = "AND"
+paths = ['''treasure-hunt-for-real-this-time-2140/donate\.html''']
+regexTarget = "line"
+regexes = ['''nostr\+walletconnect://''']


### PR DESCRIPTION
Adds two standing security scans, per review follow-up on #18:

### gitleaks (secret scanning)
- Runs on every PR and on pushes to `main`/`kotc`.
- Scans the checked-out tree (`--no-git`) so the gate is "no secrets in the code as it stands" — a historical leak can't permanently fail CI.
- `.gitleaks.toml` allowlists the Chatwoot website widget token, which is public by design (embedded on every page for visitors).

### CodeQL (JavaScript)
- Runs on PRs, pushes to `main`/`kotc`, and a weekly schedule.
- Motivation: several treasure-hunt pages render API-sourced content via `innerHTML` (`hunt.js`, `leaderboard.js`, `rabbithole.js`); a standing scan keeps DOM-XSS sinks visible.

### Resolved: NWC connection string on the donations page
The first gitleaks run flagged the Nostr Wallet Connect string embedded in `donate.html` for the `lightning-messageboard` widget. Verified in Alby Hub (app ID 5): the connection is scoped **receive-only** — create/lookup invoices + read transaction history, no `pay_invoice` — so the embed is safe by design and is now path-allowlisted in `.gitleaks.toml`. Any other secret appearing in that file still fails the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D21SvyQ2uRERDVepyADcDZ
